### PR TITLE
Kép megfelelő megjelenítése a táblázatban, kiválasztott mérettől függetlenül

### DIFF
--- a/src/components/CarsTable.jsx
+++ b/src/components/CarsTable.jsx
@@ -24,7 +24,7 @@ const columns = (deleteElement) => {
             headerAlign: 'center',
             width: 200,
             editable: false,
-            renderCell: (params) => <img src={params.value} />
+            renderCell: (params) => <img width={200} height={200} style={{objectFit: 'cover'}} src={params.value} />
         },
         {
             field: 'brand',

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -25,7 +25,7 @@ const Form = ({ onChange, fuelValue, setFuelValue, fuelValues, conditionValue, s
                     <FormControl sx={{ width: '25ch', marginTop: '10px' }}>
                         <OutlinedInput placeholder="ImageURL:" id="carImage" />
                         <FormHelperText>
-                            Image size must be (200x200)!
+                            (Suggested image size: 200x200)
                         </FormHelperText>
                     </FormControl>
                     <TextField


### PR DESCRIPTION
A táblázatban lévő képek megfelelő megjelenítésére szolgáló frissítés. Az autó feltöltésénél bármilyen méretben választható most már URL, csak egy javasolt érték van feltüntetve.